### PR TITLE
Allow configuration of multiple python virtualenvs for codejail. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ Sandboxing
 The recommended way to sandbox python is by using [CodeJail](https://github.com/edx/codejail). Create a json file like this:
 
 	{
-		"python_bin": "/path/to/sandbox/python",
-		"user": "sandbox_username"
+		"python": {
+			"python_bin": "/path/to/sandbox/python",
+			"user": "sandbox_username"
+		}
 	}
 
-And add `-j path/to/config.json` on the xqueue_watcher command. You can then import codejail.jail_code and run `jail_code("python", code...)`.
+And add `-j path/to/config.json` on the xqueue_watcher command. You can then import codejail.jail_code and run `jail_code("python", code...)`. You can define multiple sandboxes and use them as in `jail_code("special-python", ...)`
 
 The old method of sandboxing is as follows:
 

--- a/codejail_config.json
+++ b/codejail_config.json
@@ -1,4 +1,10 @@
 {
-	"python_bin": "python",
-	"user": "nobody"
+	"test-123": {
+		"python_bin": "python",
+		"user": "nobody"
+		},
+	"python": {
+		"python_bin": "/usr/bin/python",
+		"user": "nobody"
+		}
 }

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -61,15 +61,21 @@ class ManagerTests(unittest.TestCase):
     @unittest.skipUnless(HAS_CODEJAIL, "Codejail not installed")
     def test_codejail_config(self):
         config = {
-            "python_bin": "/usr/bin/python",
-            "user": "nobody",
-            "limits": {
-                "CPU": 2,
-                "VMEM": 1024
+            "python": {
+                "python_bin": "/usr/bin/python",
+                "user": "nobody",
+                "limits": {
+                    "CPU": 2,
+                    "VMEM": 1024
+                }
+            },
+            "other-python": {
+                "python_bin": "/usr/local/bin"
             }
         }
         self.m.enable_codejail(config)
         self.assertTrue(codejail.jail_code.is_configured("python"))
+        self.assertTrue(codejail.jail_code.is_configured("other-python"))
 
         # now we'll see if the codejail config is inherited in the handler subprocess
         handler_config = self.config['test1'].copy()

--- a/xqueue_watcher/manager.py
+++ b/xqueue_watcher/manager.py
@@ -67,24 +67,32 @@ class Manager(object):
         Enable codejail for the process.
         codejail_config is a dict like this:
         {
-            "python_bin": "/path/to/python",
-            "user": "sandbox_username",
-            "limits": {
-                "CPU": 1,
-                ...
+            "python": {
+                "python_bin": "/path/to/python",
+                "user": "sandbox_username",
+                "limits": {
+                    "CPU": 1,
+                    ...
+                }
+            },
+            "other-python": {
+                "python_bin": "/path/to/other/python"
             }
         }
         limits are optional
+        user defaults to the current user
         """
-        python_bin = codejail_config.get('python_bin')
-        if python_bin:
-            import codejail.jail_code
-            user = codejail_config['user']
-            codejail.jail_code.configure("python", python_bin, user=user)
-            limits = codejail_config.get("limits", {})
-            for name, value in limits.items():
-                codejail.jail_code.set_limit(name, value)
-            self.log.info("configured codejail -> %s %s", python_bin, user)
+        import codejail.jail_code
+        import getpass
+        for cj_name, config in codejail_config.items():
+            python_bin = config.get('python_bin')
+            if python_bin:
+                user = config.get('user', getpass.getuser())
+                codejail.jail_code.configure(cj_name, python_bin, user=user)
+                limits = config.get("limits", {})
+                for name, value in limits.items():
+                    codejail.jail_code.set_limit(name, value)
+                self.log.info("configured codejail -> %s %s %s", cj_name, python_bin, user)
 
     def start(self):
         """


### PR DESCRIPTION
The handler/grader will need to know what name to use when calling jail_code.

Also, process limits in codejail are currently only configurable module-wide.

@e0d 
