### PR TITLE
Retry login rather than crashing the process.

### DIFF
--- a/tests/test_xqueue_client.py
+++ b/tests/test_xqueue_client.py
@@ -221,4 +221,5 @@ class ClientTests(unittest.TestCase):
                 response.status_code = 500
 
         self.session._url_checker = urlchecker
-        self.assertFalse(self.client.run())
+        self.client.running = False
+        self.assertTrue(self.client.run())


### PR DESCRIPTION
Fixes https://openedx.atlassian.net/browse/LMS-11272 by attempting to log in every five seconds if the first time failed. Users will have to monitor the log file to know whether there's a configuration problem.

@carsongee @e0d 
