### PR TITLE
update xqueue_watcher.jailedgrader to comply with Python 3.12's removal of `imp` module

### DIFF
--- a/xqueue_watcher/grader.py
+++ b/xqueue_watcher/grader.py
@@ -2,7 +2,6 @@
 Implementation of a grader compatible with XServer
 """
 import html
-import imp
 import sys
 import time
 import json


### PR DESCRIPTION
Python 3.12 has removed the `imp` standard library module.

This PR updates certain code modules from using the deprecated `imp` to using `importlib` functionalities instead.