### PR TITLE
docs: Remove DEPR warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-⛔️ WARNING
-==========
-
-This repository is under-maintained. We are not fixing bugs or developing new features for it. We hope to deprecate and replace it soon. For updates, [follow along on the DEPR ticket](https://github.com/openedx/public-engineering/issues/22)
-
-Although we have stopped integrating new contributions, we always appreciate security disclosures and patches sent to security@openedx.org
-
 xqueue_watcher
 ==========
 


### PR DESCRIPTION
Per https://github.com/openedx/public-engineering/issues/286, we will be maintaining this repo moving forward.