### PR TITLE
fix: resolve state leak between staff-answer and submission grading passes

### DIFF
--- a/grader_support/README.md
+++ b/grader_support/README.md
@@ -47,7 +47,7 @@ Course teams create their own image `FROM grader-base` and add their grader scri
 
 ```dockerfile
 # syntax=docker/dockerfile:1
-ARG GRADER_BASE_IMAGE=ghcr.io/mitodl/xqueue-watcher-grader-base:latest
+ARG GRADER_BASE_IMAGE=ghcr.io/openedx/xqueue-watcher-grader-base:latest
 FROM ${GRADER_BASE_IMAGE}
 
 # pip must run as root; the base image ends with USER grader.

--- a/grader_support/entrypoint.py
+++ b/grader_support/entrypoint.py
@@ -123,15 +123,21 @@ def main():
     sys.path.insert(0, "/tmp")
     _dbg(f"sys.path[:4]={sys.path[:4]}")
 
-    from . import run as run_module
+    from . import run as run_module, graderutil
     from .gradelib import EndTest
 
     grader_name = os.path.splitext(os.path.basename(grader_path))[0]
     _dbg(f"grader_name={grader_name!r}")
 
-    # Run the staff answer first to get expected outputs.
+    # Run the staff answer and the student submission as two isolated in-process
+    # imports of the grader module. Without module_isolation(), the second
+    # run_module.run() call below would hit Python's sys.modules cache instead of
+    # re-executing the grader module, silently reusing whatever mutable
+    # module-level state (generators, shared dicts/lists, gradelib.rand snapshotted
+    # via `from gradelib import *`) the first run left behind.
     _dbg("running staff answer")
-    expected_output = run_module.run(grader_name, "answer", seed)
+    with graderutil.module_isolation():
+        expected_output = run_module.run(grader_name, "answer", seed)
     _dbg(f"expected_output grader status={expected_output['grader']['status']!r}"
          f"  submission status={expected_output['submission']['status']!r}"
          f"  exceptions={expected_output['exceptions']}"
@@ -156,7 +162,8 @@ def main():
 
     # Run the student submission.
     _dbg("running student submission")
-    actual_output = run_module.run(grader_name, "submission", seed)
+    with graderutil.module_isolation():
+        actual_output = run_module.run(grader_name, "submission", seed)
     _dbg(f"actual_output grader status={actual_output['grader']['status']!r}"
          f"  submission status={actual_output['submission']['status']!r}"
          f"  exceptions={actual_output['exceptions']}"

--- a/grader_support/entrypoint.py
+++ b/grader_support/entrypoint.py
@@ -61,14 +61,27 @@ def main():
     trans.install(names=None)
     _dbg("gettext installed")
 
+    from . import run as run_module, graderutil
+    from .gradelib import EndTest
+
     # Load the grader module to access test definitions, preprocessors, and
     # input validators.  The grader script is baked into this image.
+    #
+    # This load (and each run_module.run() call below) is wrapped in its own
+    # graderutil.module_isolation() so that any modules it causes to be
+    # imported -- the grader module itself, and any helper modules the grader
+    # script imports -- are purged from sys.modules once we're done with them.
+    # Without this, module-level mutable state in those modules could leak
+    # into the later staff-answer/submission runs even though those runs are
+    # separately isolated from each other, because module_isolation() only
+    # rolls back modules imported *after* it takes its snapshot.
     _dbg(f"loading grader module from {grader_path!r}")
     try:
-        spec = importlib.util.spec_from_file_location("grader_module", grader_path)
-        grader_module_obj = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(grader_module_obj)
-        grader = grader_module_obj.grader
+        with graderutil.module_isolation():
+            spec = importlib.util.spec_from_file_location("grader_module", grader_path)
+            grader_module_obj = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(grader_module_obj)
+            grader = grader_module_obj.grader
         _dbg(f"grader module loaded OK, tests={len(list(grader.tests()))}")
     except Exception:
         _dbg("EXCEPTION loading grader module:")
@@ -122,9 +135,6 @@ def main():
     sys.path.insert(0, grader_dir)
     sys.path.insert(0, "/tmp")
     _dbg(f"sys.path[:4]={sys.path[:4]}")
-
-    from . import run as run_module, graderutil
-    from .gradelib import EndTest
 
     grader_name = os.path.splitext(os.path.basename(grader_path))[0]
     _dbg(f"grader_name={grader_name!r}")


### PR DESCRIPTION
## Description

`grader_support/entrypoint.py` grades the staff answer and the student submission in the same process, via two calls to `run_module.run()`. `run.py` imports the grader module by name with `__import__()`, and Python only executes a module's top-level code on the *first* import — the second call was silently reusing the cached module object, mutated leftovers and all.

Any grader with module-level mutable state leaked state from the first pass into the second:
- generators (e.g. an `inputOracle()` mocking `input()`) got exhausted by the first pass, so the second pass raised immediately
- a shared list/dict mutated in place by the first pass carried its final state into the second pass
- `rand` (bound via `from gradelib import *`) is a snapshot taken at import time, so it kept the *first* pass's already-advanced RNG instead of the freshly reseeded one `run.py` intends

Downstream course teams (MITx/mitodl) traced a long list of "broken grader" reports to this single gap: exhausted `input()` mocks, results "feeding into themselves" between runs, wrong balances on stateful exec environments, and OOP/generator graders failing while structurally similar ones using stdlib `random.randint()` — immune to the leak, since `run.py` reseeds the *global* `random` module correctly on every call — kept "working".

The fix wraps each `run_module.run()` call in `graderutil.module_isolation()`, a context manager that already existed in this file's own `graderutil` import but was never actually used.

## Testing

`uv run pytest tests/` — all 118 existing tests pass.

Manual repro (pre-fix): grade a grader with module-level generator state against its own `answer.py` inside the grader-base container — the second (student) pass gets an already-exhausted generator and scores 0.0 even though the submission is byte-identical to the answer. Post-fix, both passes produce matching output and it scores 1.0.

## Deadline

None known.

## Other information

This was found and verified via two downstream course-content repos that both hit it independently. Companion PR (same fix) in the mitodl fork: https://github.com/mitodl/xqueue-watcher/pull/15
